### PR TITLE
Add submission instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Submission Instructions
 
-Once you have completed the hometask, please submit your solution via email to:
+Once you have completed the assignment, please submit your solution via email to:
 
 **interview-kotlin@deblock.com**
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+## Submission Instructions
+
+Once you have completed the hometask, please submit your solution via email to:
+
+**interview-kotlin@deblock.com**
+
+Your solution must be attached as a ZIP file following this naming pattern: `{first_name}_{last_name}.zip`
+
+For example: `john_doe.zip`
+
+---
+
 **Deblock - Problem to be solved**
 
 **Background:**


### PR DESCRIPTION
Added clear submission instructions at the top of README.md specifying:
- Email: interview-kotlin@deblock.com
- Zip file naming format: {first_name}_{last_name}.zip
- Example: john_doe.zip